### PR TITLE
fix : 한글 키보드 입력 시 이벤트가 두 번 호출되는 오류 수정

### DIFF
--- a/frontend/components/chat/ChatInput.js
+++ b/frontend/components/chat/ChatInput.js
@@ -343,6 +343,7 @@ const ChatInput = forwardRef(({
           return;
       }
     } else if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.nativeEvent.isComposing) return;
       e.preventDefault();
       if (message.trim() || files.length > 0) {
         handleSubmit(e);


### PR DESCRIPTION
# 🐛 Fix: 한글 IME 중복 입력 버그 해결

## 문제
한글 입력 시 IME 조합 중에 Enter 키가 눌렸을 때 메시지가 의도치 않게 전송되는 버그

## 해결
`e.nativeEvent.isComposing` 체크를 추가하여 IME 조합 상태일 때 Enter 키 이벤트를 무시하도록 수정

## 수정 파일
- `frontend/components/chat/ChatInput.js`
- `frontend/hooks/useChatRoom.js`

## 변경사항
```javascript
// 수정 전
} else if (e.key === 'Enter' && !e.shiftKey) {
  e.preventDefault();
  handleSubmit(e);
}

// 수정 후  
} else if (e.key === 'Enter' && !e.shiftKey) {
  if (e.nativeEvent.isComposing) return;
  e.preventDefault();
  handleSubmit(e);
}
```

## 테스트
- ✅ 한글 입력 중 Enter 키 입력 시 메시지 전송되지 않음
- ✅ 한글 입력 완료 후 Enter 키 입력 시 정상 전송
- ✅ 영어/숫자 입력 시 정상 동작
- ✅ Shift + Enter 줄바꿈 기능 정상 동작