### PR TITLE
fix: vapor-ui 라이브러리에서 존재하지 않는 아이콘 사용하는 오류 수정

### DIFF
--- a/frontend/components/DuplicateLoginModal.js
+++ b/frontend/components/DuplicateLoginModal.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { WarningIcon, TimeIcon, ExternalLinkIcon } from '@vapor-ui/icons';
+import { WarningIcon, TimeIcon, LinkOutlineIcon as ExternalLinkIcon } from '@vapor-ui/icons';
 import { Button, Text, Callout } from '@vapor-ui/core';
 
 const DuplicateLoginModal = ({ 

--- a/frontend/components/chat/FilePreview.js
+++ b/frontend/components/chat/FilePreview.js
@@ -6,7 +6,7 @@ import {
   PdfIcon as FileText, 
   MovieIcon as Film, 
   LoadingOutlineIcon as Loader,
-  MusicIcon as Music,
+  SoundOnIcon as Music,
   FileIcon as File
 } from '@vapor-ui/icons';
 import { Button, IconButton, Callout } from '@vapor-ui/core';

--- a/frontend/components/chat/Message/FileMessage.js
+++ b/frontend/components/chat/Message/FileMessage.js
@@ -5,8 +5,8 @@ import {
   MovieIcon as Film, 
   CorrectOutlineIcon as CheckCheck, 
   CorrectOutlineIcon as Check, 
-  MusicIcon as Music, 
-  ExternalLinkIcon as ExternalLink, 
+  SoundOnIcon as Music, 
+  LinkOutlineIcon as ExternalLink, 
   DownloadIcon as Download,
   ErrorCircleIcon as AlertCircle 
 } from '@vapor-ui/icons';


### PR DESCRIPTION

## 원인
`@vapor-ui/icons`에서 존재하지 않는 아이콘들을 import하려고 시도했기 때문입니다:
- `ExternalLinkIcon` → 존재하지 않음
- `MusicIcon` → 존재하지 않음


### 아이콘 매핑 테이블
| 기존 아이콘 | 새로운 아이콘 | 용도 |
|------------|-------------|------|
| `ExternalLinkIcon` | `LinkOutlineIcon` | 외부 링크, 새 탭에서 보기 |
| `MusicIcon` | `SoundOnIcon` | 오디오 파일 아이콘 |

## 결과
- ✅ 이미지 전송 시 FileActions 컴포넌트 에러 해결
- ✅ 파일 메시지의 액션 버튼들이 정상적으로 렌더링됨
- ✅ 아이콘들이 올바르게 표시됨
- ✅ 파일 다운로드 및 새 탭에서 보기 기능 정상 동작

## 테스트 시나리오
- [x] 이미지 파일 전송 시 에러 없이 정상 동작
- [x] 비디오 파일 전송 시 에러 없이 정상 동작
- [x] 오디오 파일 전송 시 에러 없이 정상 동작
- [x] PDF 파일 전송 시 에러 없이 정상 동작
- [x] 파일 액션 버튼들(다운로드, 새 탭에서 보기) 정상 동작
